### PR TITLE
Add reset-boot for FTDI using NodeMCU reset circuit.

### DIFF
--- a/espcomm/espcomm_boards.c
+++ b/espcomm/espcomm_boards.c
@@ -103,7 +103,8 @@ void board_wifio_ra()
     serialport_set_dtr(1);
 }
 
-void board_ftdi_rb()
+
+void board_nodemcu_rb()
 {
     serialport_set_rts(1);
     serialport_set_dtr(0);
@@ -114,7 +115,7 @@ void board_ftdi_rb()
     serialport_set_rts(0);
 }
 
-void board_ftdi_ra()
+void board_nodemcu_ra()
 {
     serialport_set_dtr(0);
     serialport_set_rts(1);
@@ -128,7 +129,7 @@ static espcomm_board_t s_boards[] = {
     { "none",   0,                  0               },
     { "ck",     &board_ck_rb,       &board_ck_ra    },
     { "wifio",  &board_wifio_rb,    &board_wifio_ra},
-    { "ftdi",   &board_ftdi_rb,     &board_ftdi_ra},
+    { "nodemcu",   &board_nodemcu_rb,     &board_nodemcu_ra},
 };
 
 static size_t s_boards_count = sizeof(s_boards) / sizeof(espcomm_board_t);

--- a/espcomm/espcomm_boards.c
+++ b/espcomm/espcomm_boards.c
@@ -103,7 +103,24 @@ void board_wifio_ra()
     serialport_set_dtr(1);
 }
 
+void board_ftdi_rb()
+{
+    serialport_set_rts(1);
+    serialport_set_dtr(0);
+    espcomm_delay_ms(5);
+    serialport_set_rts(0);
+    serialport_set_dtr(1);
+    espcomm_delay_ms(50);
+    serialport_set_rts(0);
+}
 
+void board_ftdi_ra()
+{
+    serialport_set_dtr(0);
+    serialport_set_rts(1);
+    espcomm_delay_ms(5);
+    serialport_set_rts(0);
+}
 
 /// list of all boards
 
@@ -111,6 +128,7 @@ static espcomm_board_t s_boards[] = {
     { "none",   0,                  0               },
     { "ck",     &board_ck_rb,       &board_ck_ra    },
     { "wifio",  &board_wifio_rb,    &board_wifio_ra},
+    { "ftdi",   &board_ftdi_rb,     &board_ftdi_ra},
 };
 
 static size_t s_boards_count = sizeof(s_boards) / sizeof(espcomm_board_t);


### PR DESCRIPTION
Add a new reset to bootloader method for FTDI chip when using reset
circuit similar to NodeMCU.
The "ck" method cannot be used (ESP8266 cannot be reset).
