### PR TITLE
Committer: Roland Zitzke

### DIFF
--- a/serialport/serialport.c
+++ b/serialport/serialport.c
@@ -310,7 +310,7 @@ void serialport_set_character_timeout_0_1s(unsigned int t)
 {
     if (t > 255)
         t = 255;
-
+#ifndef __APPLE__
     term.c_cc[VMIN]  = 0;
     term.c_cc[VTIME] = t;  // VTIME is measured in 0.1s
 
@@ -322,6 +322,7 @@ void serialport_set_character_timeout_0_1s(unsigned int t)
     }
     
     LOGDEBUG("done");
+#endif
     timeout = t;
 }
 


### PR DESCRIPTION
Disabled character timeouts on OS X since it creates unpredictable results with several serial drivers e.g. CH34x
It looks like this is specific to OS X and it is related to the inability of the USB driver to handle short timeouts. Unless there comes up a better solution I suggest to stick with the defaults for timeouts. I have tested it with OS X 10.11.3 without running into problems.
The drawback might be that the calling process gets stuck in case of an infinite timeout.
