### PR TITLE
rely on compiler defined platform flags

### DIFF
--- a/espcomm/delay.c
+++ b/espcomm/delay.c
@@ -23,7 +23,7 @@
  **/
 
 
-#if defined (WINDOWS)
+#if defined(_WIN32)
 #include <Windows.h>
 
 void espcomm_delay_ms(int ms)

--- a/espcomm/delay.c
+++ b/espcomm/delay.c
@@ -24,7 +24,7 @@
 
 
 #if defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 
 void espcomm_delay_ms(int ms)
 {

--- a/espcomm/espcomm.c
+++ b/espcomm/espcomm.c
@@ -49,12 +49,12 @@ static bool upload_stage = false;
 static bool espcomm_is_open = false;
 
 static const char *espcomm_port =
-#if defined(LINUX)
-"/dev/ttyUSB0";
-#elif defined(WINDOWS)
-"COM1";
-#elif defined(OSX)
+#if defined(__APPLE__) && defined(__MACH__)
 "/dev/tty.usbserial";
+#elif defined(_WIN32)
+"COM1";
+#elif defined(__linux__)
+"/dev/ttyUSB0";
 #else
 "";
 #endif


### PR DESCRIPTION
The latest release v0.4.12 has lost default serial port definition due to recent changes in build environment. Lets use compiler defined platform flags as they are more consistent and reliable. 