### PR TITLE
Add new dtrset mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ none       | No DTR/RTS manipulation
 ck         | RTS controls RESET or CH_PD, DTR controls GPIO0
 wifio      | TXD controls GPIO0 via PNP transistor and DTR controls RESET via a capacitor
 nodemcu    | GPIO0 and RESET controlled using two NPN transistors as in [NodeMCU devkit](https://raw.githubusercontent.com/nodemcu/nodemcu-devkit/master/Documents/NODEMCU_DEVKIT_SCH.png).
+dtrset     | DTR is set during serial communications
 
 Examples
 --------

--- a/espcomm/espcomm_boards.c
+++ b/espcomm/espcomm_boards.c
@@ -103,7 +103,6 @@ void board_wifio_ra()
     serialport_set_dtr(1);
 }
 
-
 void board_nodemcu_rb()
 {
     serialport_set_rts(1);
@@ -123,13 +122,26 @@ void board_nodemcu_ra()
     serialport_set_rts(0);
 }
 
+// dtrset board: DTR is set during serial communications
+
+void board_dtrset_rb()
+{
+    serialport_set_dtr(1);  // This makes dtr active by setting line voltage low
+}
+
+void board_dtrset_ra()
+{
+    serialport_set_dtr(0);
+}
+
 /// list of all boards
 
 static espcomm_board_t s_boards[] = {
-    { "none",   0,                  0               },
-    { "ck",     &board_ck_rb,       &board_ck_ra    },
-    { "wifio",  &board_wifio_rb,    &board_wifio_ra},
-    { "nodemcu",   &board_nodemcu_rb,     &board_nodemcu_ra},
+    { "none",   0,                  0                  },
+    { "ck",      &board_ck_rb,       &board_ck_ra      },
+    { "wifio",   &board_wifio_rb,    &board_wifio_ra   },
+    { "nodemcu", &board_nodemcu_rb,  &board_nodemcu_ra },
+    { "dtrset",  &board_dtrset_rb,   &board_dtrset_ra  },
 };
 
 static size_t s_boards_count = sizeof(s_boards) / sizeof(espcomm_board_t);


### PR DESCRIPTION
The reason this mode is needed is because some usb serial drivers (one example is the Arduino Due's native usb serial) expect dtr to be active or it refuses to write to serial.  Other than setting dtr during serial communications this mode acts like none so the intermediate micro being communicated through needs to handle resetting the esp chip.