### PR TITLE
Fixed some formatting errors in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Argument | Description
 ```-es <section> <filename>``` | Read the given section from the ELF file and make a raw dump into the specified file.
 ```-ec``` | Close the currently opened ELF file
 ```-bo <filename> ```| Prepare a firmware file in the format that is understood by the ESP chip. Works only if an ELF file is opened, and if no firmware file is prepared yet. Upon -bo the tool will start out with an empty image where only the main header is set up. The result of the operations done on the firmware image is saved when the it is finally closed using -bc command.
-```-bm <qio|qout|dio|dout>``` | Set the flash chip interface mode. Default is QIO. This parameter is stored in the binary image header, along with the flash size and flash frequency. The ROM bootloader in the ESP8266 uses the value of these parameters in order to know how to talk to the flash chip.
-```-bz <512K|256K|1M|2M|4M|8M|16M|32M>``` | Set the flash chip size. Default is 512K.
-```-bf <40|26|20|80>``` | Set the flash chip frequency, in MHz. Default is 40M.
+```-bm <qio/qout/dio/dout>``` | Set the flash chip interface mode. Default is QIO. This parameter is stored in the binary image header, along with the flash size and flash frequency. The ROM bootloader in the ESP8266 uses the value of these parameters in order to know how to talk to the flash chip.
+```-bz <512K/256K/1M/2M/4M/8M/16M/32M>``` | Set the flash chip size. Default is 512K.
+```-bf <40/26/20/80>``` | Set the flash chip frequency, in MHz. Default is 40M.
 ```-bs <section>``` | Read the specified section from the ELF file and append it to the firmware image. Sections will appear in the firmware image in the exact same order as the -bs commands are executed.
 ```-bp <size>``` | Finalize the firmware image, padding it with `0xaa` value until it is at least `<size>` bytes long. Unlike `-bc`, this doesn't close the file. This option can be used to combine bootloader with the rest of the application
 ```-br <size>``` | Pad all the following sections to multiples of `<size>`. Default is 4 bytes. This option can be used to place sections on specific boundaries, e.g. 4k or 64k.


### PR DESCRIPTION
"|" is used for next column, changed it to "/"