### PR TITLE
Support setting arbitrary baud rates in the *nix compilations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ endif # TARGET_OS
 
 # OS-specific settings and build flags
 ifeq ($(TARGET_OS),win32)
+	TARGET_CFLAGS   = -D_WIN32
 	ARCHIVE ?= zip
 	TARGET := esptool.exe
 	TARGET_LDFLAGS = -Wl,-static -static-libgcc

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ OBJECTS := \
 	espcomm/espcomm_boards.o \
 	infohelper/infohelper.o \
 	serialport/serialport.o \
+	serialport/weirdbaud.o \
 	main.o
 
 INCLUDES := $(addprefix -I,$(MODULES))

--- a/serialport/weirdbaud.c
+++ b/serialport/weirdbaud.c
@@ -1,3 +1,4 @@
+#ifdef _WIN32
 #include <stdio.h>
 #include <fcntl.h>
 #include <asm/termios.h>
@@ -13,3 +14,9 @@ int weirdbaud (int serial_port, int speed) {
 	int r = ioctl(serial_port, TCSETS2, &tio);
 	return r;
 }
+#else
+// I don't know how to do this for WIN32, so it's a stub that returns failure...
+int weirdbaud (int serial_port, int speed) {
+	return(1);
+}
+#endif

--- a/serialport/weirdbaud.c
+++ b/serialport/weirdbaud.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <asm/termios.h>
+extern int ioctl (int __fd, unsigned long int __request, ...) __THROW;
+
+int weirdbaud (int serial_port, int speed) {
+	struct termios2 tio;
+	ioctl(serial_port, TCGETS2, &tio);
+	tio.c_cflag &= ~CBAUD;
+	tio.c_cflag |= BOTHER;
+	tio.c_ispeed = speed;
+	tio.c_ospeed = speed;
+	int r = ioctl(serial_port, TCSETS2, &tio);
+	return r;
+}


### PR DESCRIPTION
I was having a rough time getting my Wemos D1 mini lite devices to reset consistently.  I discovered that they were setting themselves at 78440 baud.  I don't know the protocol here, but from my memory of Days of Olde, the AT convention was designed such that DCE could divine the baud rate by examining the timing of the bits in those characters.  In any case, I took a chance and adapted this code to support arbitrary baud rates so that I could do the reset/firmware transfer at 78440 to please my gizmo.  It seems to have solved my problem.  Or I am coincidentally lucky.  Whatever... sharing the code back.  It's ugly and hacky but it does the job without a lot of clutter.  Maybe really useful?  Thanks for your efforts.