### PR TITLE
docs: fix simple typo, verbositiy -> verbosity

### DIFF
--- a/infohelper/infohelper.h
+++ b/infohelper/infohelper.h
@@ -2,7 +2,7 @@
  **********************************************************************************
  ***
  ***    infohelper.h
- ***    - defines and prototypes for a crude verbositiy-controllabe info output
+ ***    - defines and prototypes for a crude verbosity-controllabe info output
  ***
  ***    Copyright (C) 2014 Christian Klippel <ck@atelier-klippel.de>
  ***
@@ -27,7 +27,7 @@
 
 
 /*
-** set verbositiy level
+** set verbosity level
 ** 0 = only error messages
 ** 1 = warnings
 ** 2 = information messages (default)


### PR DESCRIPTION
There is a small typo in infohelper/infohelper.h.

Should read `verbosity` rather than `verbositiy`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md